### PR TITLE
Improve build and deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,14 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify deployment source
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
+        

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Gatsby Deploy
 
-on:
+on: push
   # push:
   #   branches: main
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Gatsby Deploy
 
-on: push
-  # push:
-  #   branches: main
+on:
+  push:
+    branches: ${{ github.event.repository.default_branch }}
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,8 @@
 name: Gatsby Deploy
 
 on:
-  push:
-    branches: main
-
-env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  # push:
+  #   branches: main
 
 jobs:
   build:
@@ -13,8 +10,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v3
       - name: Build
-        uses: enriikke/gatsby-gh-pages-action@v2
+        run: |
+          npm install && npm run build
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
-          deploy-branch: gh-pages
+          path: public/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Stop using `enriikke/gatsby-gh-pages-action@v2`.

Instead create separate `build` and `deploy` jobs that use:
* npm script to build
* `actions/upload-pages-artifact` to create artifact
* `actions/deploy-pages` to deploy